### PR TITLE
12.0 stock ehe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/packethost_stock/__init__.py
+++ b/packethost_stock/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/packethost_stock/__manifest__.py
+++ b/packethost_stock/__manifest__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Packet Host: Stock Customization',
+    'summary': 'Packet Host : Warehouse Filter on Transfers',
+    'description':"""
+    Task ID: 1962968
+    1) Warehouse filter on transfers.
+    1.1) By Creating a Warehouse filter on transfers, the transfer will only show operation types that apply to that warehouse, simplifying the process and reducing the amount of errors that can be made by the users.
+    """,
+    'license': 'OEEL-1',
+    'author': 'Odoo Inc',
+    'version': '0.1',
+    'depends': ['stock'],
+    'data': [
+        'views/stock_picking_views.xml',
+    ],
+}

--- a/packethost_stock/models/__init__.py
+++ b/packethost_stock/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import stock_picking

--- a/packethost_stock/models/stock_picking.py
+++ b/packethost_stock/models/stock_picking.py
@@ -7,8 +7,16 @@ class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'
 
     show_on_picking = fields.Boolean('Show on Picking')
-    no_show_location_on_picking = fields.Boolean('Not Show Source Location on Picking')
-    no_show_location_dest_on_picking = fields.Boolean('Not Show Destination Location on Picking')
+    no_show_location_on_picking = fields.Boolean('Not Show Selectable Source Location on Picking',
+                                                 help='When this box is checked, '
+                                                      'source location for this operation type will not show as '
+                                                      'a dropdown selectable option on transfer form, '
+                                                      'but will be logged in the chatter.')
+    no_show_location_dest_on_picking = fields.Boolean('Not Show Selectable Destination Location on Picking',
+                                                      help='When this box is checked, '
+                                                      'destination location for this operation type will not show as '
+                                                      'a dropdown selectable option on transfer form, '
+                                                      'but will be logged in the chatter.')
 
 
 class StockPicking(models.Model):

--- a/packethost_stock/models/stock_picking.py
+++ b/packethost_stock/models/stock_picking.py
@@ -2,7 +2,21 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    show_on_picking = fields.Boolean('Show on Picking')
+    no_show_location_on_picking = fields.Boolean('Not Show Source Location on Picking')
+    no_show_location_dest_on_picking = fields.Boolean('Not Show Destination Location on Picking')
+
+
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     warehouse_id = fields.Many2one('stock.warehouse', ondelete='set null', string='Warehouse')
+    no_show_location_on_picking = fields.Boolean(related='picking_type_id.no_show_location_on_picking', readonly=True)
+    no_show_location_dest_on_picking = fields.Boolean(related='picking_type_id.no_show_location_dest_on_picking', readonly=True)
+
+    location_id = fields.Many2one('stock.location', track_visibility='onchange')
+    location_dest_id = fields.Many2one('stock.location', track_visibility='onchange')

--- a/packethost_stock/models/stock_picking.py
+++ b/packethost_stock/models/stock_picking.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    warehouse_id = fields.Many2one('stock.warehouse', ondelete='set null', string='Warehouse')

--- a/packethost_stock/views/stock_picking_views.xml
+++ b/packethost_stock/views/stock_picking_views.xml
@@ -6,11 +6,37 @@
             <field name="model">stock.picking</field>
             <field name="inherit_id" ref="stock.view_picking_form"/>
             <field name="arch" type="xml">
-              <xpath expr="//field[@name='picking_type_id']" position="before">
-                <field name="warehouse_id"/>
-              </xpath>
-              <xpath expr="//field[@name='picking_type_id']" position="attributes">
-                <attribute name="domain">[('warehouse_id', '=', warehouse_id)]</attribute>
+                <!--we first replace the picking type since we want to move it somewhere else-->
+                <xpath expr="//field[@name='picking_type_id']" position="replace"/>
+
+                <xpath expr="//field[@name='location_id']" position="before">
+                    <field name="warehouse_id" required="1"/>
+                    <field name="no_show_location_on_picking" invisible="1"/>
+                    <field name="no_show_location_dest_on_picking" invisible="1"/>
+                    <field name="picking_type_id" string="Task" attrs="{'readonly': [('state', '!=', 'draft')]}" domain="[('warehouse_id', '=', warehouse_id), ('show_on_picking', '=', True)]"/>
+                </xpath>
+
+                <xpath expr="//field[@name='location_id']" position="attributes">
+                    <attribute name="attrs">{'invisible': ['|', ('picking_type_code','=','incoming'), ('no_show_location_on_picking', '=', True)], 'readonly': [('state','not in',['draft'])]}
+                    </attribute>
+                </xpath>
+                <xpath expr="//field[@name='location_dest_id']" position="attributes">
+                    <attribute name="attrs">{'invisible': ['|', ('picking_type_code','=','outgoing'), ('no_show_location_dest_on_picking', '=', True)], 'readonly': [('state','not in',['draft'])]}
+                    </attribute>
+                </xpath>
+
+            </field>
+        </record>
+
+        <record id="view_stock_view_picking_type_form_packethost" model="ir.ui.view">
+            <field name="name">stock_view_picking_type_form_packethost</field>
+            <field name="model">stock.picking.type</field>
+            <field name="inherit_id" ref="stock.view_picking_type_form"/>
+            <field name="arch" type="xml">
+              <xpath expr="//field[@name='show_operations']" position="after">
+                  <field name="show_on_picking"/>
+                  <field name="no_show_location_on_picking"/>
+                  <field name="no_show_location_dest_on_picking"/>
               </xpath>
 
             </field>

--- a/packethost_stock/views/stock_picking_views.xml
+++ b/packethost_stock/views/stock_picking_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="view_stock_view_picking_form_packethost" model="ir.ui.view">
+            <field name="name">stock_view_picking_form_packethost</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="arch" type="xml">
+              <xpath expr="//field[@name='picking_type_id']" position="before">
+                <field name="warehouse_id"/>
+              </xpath>
+              <xpath expr="//field[@name='picking_type_id']" position="attributes">
+                <attribute name="domain">[('warehouse_id', '=', warehouse_id)]</attribute>
+              </xpath>
+
+            </field>
+        </record>
+    </data>
+</odoo>
+

--- a/packethost_stock/views/stock_picking_views.xml
+++ b/packethost_stock/views/stock_picking_views.xml
@@ -10,7 +10,7 @@
                 <xpath expr="//field[@name='picking_type_id']" position="replace"/>
 
                 <xpath expr="//field[@name='location_id']" position="before">
-                    <field name="warehouse_id" required="1"/>
+                    <field name="warehouse_id" attrs="{'readonly': [('state', '!=', 'draft')], 'required': [('state', '=', 'draft')]}"/>
                     <field name="no_show_location_on_picking" invisible="1"/>
                     <field name="no_show_location_dest_on_picking" invisible="1"/>
                     <field name="picking_type_id" string="Task" attrs="{'readonly': [('state', '!=', 'draft')]}" domain="[('warehouse_id', '=', warehouse_id), ('show_on_picking', '=', True)]"/>


### PR DESCRIPTION
ID = 1962968

At some point the original spec was modified to the following:

Under “Task”: This field should not be the operation types in Odoo. As per the sketch that was sent over, the options would be - 
1. Rack Server 
2. Unrack Server 
3. Transit

When Task = “Rack Server”, Source Location and Destination Location should populate the stock location based on the warehouse chosen above and NO SELECTION should be allowed for the user. E.g. 
Warehouse: EWR
Task: Rack Server
Source Location: EWR/Stock
Destination Location: EWE/Stock/Enrolled Servers EWR

For Task = "Unrack Server," the logic is the same. Again, the Source Location and the Destination Location should be automatically populated based on the Task and the Warehouse entered.
Warehouse: DFW
Task: Unrack Server
Source Location: DFW/Stock/Enrolled Servers DFW
Destination Location: DFW/Stock

For Task = “Transit”, Source Location is populated based on the Warehouse that has been specified and SELECTION IS ENABLED for Destination Location 
Warehouse: EWR
Task: Transit
Source Location: EWR/Stock (SELECTION NOT ENABLED and AUTOMATICALLY POPULATED BASED ON WAREHOUSE SPECIFIED ABOVE)
Destination Location: ATL/Stock (SELECTION ENABLED)